### PR TITLE
 Add class support using Builder(ClassName) syntax.

### DIFF
--- a/__tests__/Builder.test.ts
+++ b/__tests__/Builder.test.ts
@@ -74,7 +74,7 @@ describe('Builder', () => {
         c: true
       };
 
-      const builder = Builder<Testing>(template);
+      const builder = Builder(template);
 
       expect(builder.build()).toEqual(template);
     });

--- a/__tests__/Builder.test.ts
+++ b/__tests__/Builder.test.ts
@@ -6,6 +6,12 @@ interface Testing {
   c: boolean;
 }
 
+class TestingClass implements Testing {
+  public a!: number;
+  public b!: string;
+  public c!: boolean;
+}
+
 describe('Builder', () => {
   it('should build', () => {
     const builder = Builder<Testing>()
@@ -18,6 +24,21 @@ describe('Builder', () => {
       b: 'abc',
       c: true
     });
+  });
+
+  it('should build a class', () => {
+    const builder = Builder(TestingClass)
+        .a(10)
+        .b('abc')
+        .c(true);
+
+    const result = builder.build();
+    expect(result).toEqual({
+      a: 10,
+      b: 'abc',
+      c: true
+    });
+    expect(result).toBeInstanceOf(TestingClass);
   });
 
   it('might build broken objects if you do not pay attention', () => {
@@ -35,6 +56,16 @@ describe('Builder', () => {
     });
   });
 
+  it("won't build broken classes", () => {
+    const builder = Builder(TestingClass).a(10);
+    const built = builder.build();
+    expect(builder.build()).toEqual({
+      a: 10,
+      b: undefined,
+      c: undefined
+    });
+  });
+
   describe('with template object', () => {
     it('should build the template object', () => {
       const template: Testing = {
@@ -43,7 +74,7 @@ describe('Builder', () => {
         c: true
       };
 
-      const builder = Builder(template);
+      const builder = Builder<Testing>(template);
 
       expect(builder.build()).toEqual(template);
     });
@@ -65,6 +96,25 @@ describe('Builder', () => {
       });
     });
 
+    it('should build a modified class template', () => {
+      const template: Testing = {
+        a: 10,
+        b: 'abc',
+        c: true
+      };
+
+      const builder = Builder(TestingClass, template)
+          .a(42);
+
+      const result = builder.build();
+      expect(result).toEqual({
+        a: 42,
+        b: 'abc',
+        c: true
+      });
+      expect(result).toBeInstanceOf(TestingClass);
+    });
+
     it('should not modify the template object', () => {
       const template: Testing = {
         a: 10,
@@ -83,5 +133,21 @@ describe('Builder', () => {
       });
     });
 
+    it('should not modify the template class', () => {
+      const template: TestingClass = new TestingClass();
+      template.a = 10;
+      template.b = 'abc';
+      template.c = true;
+
+      Builder(template)
+          .a(42)
+          .build();
+
+      expect(template).toEqual({
+        a: 10,
+        b: 'abc',
+        c: true
+      });
+    });
   });
 });

--- a/src/Builder.ts
+++ b/src/Builder.ts
@@ -5,7 +5,34 @@ export type IBuilder<T> = {
   build(): T
 };
 
-export function Builder<T>(template?: T): IBuilder<T> {
+type Clazz<T> = new(...args: any[]) => T;
+
+/**
+ * Create a Builder for a class. Returned objects will be of the class type.
+ *
+ * e.g. let obj: MyClass = Builder(MyClass).setA(5).setB("str").build();
+ * @param type the name of the class to instantiate.
+ * @param template optional class partial which the builder will derive initial params from.
+ */
+export function Builder<T>(type: Clazz<T>, template?: Partial<T>): IBuilder<T>;
+
+/**
+ * Create a Builder for an interface. Returned objects will be untyped.
+ *
+ * e.g. let obj: Interface = Builder<Interface>().setA(5).setB("str").build();
+ * @param template optional partial object which the builder will derive initial params from.
+ */
+export function Builder<T>(template?: Partial<T>): IBuilder<T>;
+
+export function Builder<T>(typeOrTemplate?: Clazz<T> | Partial<T>,
+                           template?: Partial<T>): IBuilder<T> {
+  let type: Clazz<T>|undefined;
+  if (typeOrTemplate instanceof Function) {
+    type = typeOrTemplate as Clazz<T>;
+  } else {
+    template = typeOrTemplate;
+  }
+
   const built: any = template ? Object.assign({}, template) : {};
 
   const builder = new Proxy(
@@ -13,7 +40,14 @@ export function Builder<T>(template?: T): IBuilder<T> {
     {
       get(target, prop, receiver) {
         if ('build' === prop) {
-          return () => built;
+          if (type) {
+            // A class name (identified by the constructor) was passed. Instantiate it with props.
+            const obj: T = new type();
+            return () => Object.assign(obj, {...built});
+          } else {
+            // No type information - just return the object.
+            return () => built;
+          }
         }
 
         return (x: any): any => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "experimentalDecorators": true,
     "removeComments": false,
     "strict": true,
+    "strictNullChecks": true,
     "declaration": false
   },
   "include": [


### PR DESCRIPTION
I needed to create typed builders for classes so I could call methods on the created objects (and use them in web components). Thought you might be interested in the extension.