### PR TITLE
Added: Ensuring set methods are not optional

### DIFF
--- a/__tests__/Builder.test.ts
+++ b/__tests__/Builder.test.ts
@@ -4,6 +4,7 @@ interface Testing {
   a: number;
   b: string;
   c: boolean;
+  d?: number;
 }
 
 class TestingClass implements Testing {
@@ -49,17 +50,34 @@ describe('Builder', () => {
     // object not matching the type
     const built = builder.build();
 
-    expect(builder.build()).toEqual({
+    expect(built).toEqual({
       a: 10,
       b: undefined,
       c: undefined
     });
   });
 
+  it('will set methods as required', () => {
+    // Note that d is optional, however it's set method is not
+    const builder = Builder<Testing>()
+        .a(10)
+        .b('abc')
+        .c(true)
+        .d(20);
+    const result = builder.build();
+
+    expect(result).toEqual({
+      a: 10,
+      b: 'abc',
+      c: true,
+      d: 20
+    });
+  });
+
   it("won't build broken classes", () => {
     const builder = Builder(TestingClass).a(10);
     const built = builder.build();
-    expect(builder.build()).toEqual({
+    expect(built).toEqual({
       a: 10,
       b: undefined,
       c: undefined

--- a/src/Builder.ts
+++ b/src/Builder.ts
@@ -1,5 +1,5 @@
 export type IBuilder<T> = {
-  [k in keyof T]: (arg: T[k]) => IBuilder<T>
+  [k in keyof T]-?: (arg: T[k]) => IBuilder<T>
 }
 & {
   build(): T


### PR DESCRIPTION
This resolves the issue where, if a type passed into the builder has an optional property, you're forced to use the Non-null assertion operator (`!`) in order to call the set method.

I can't think of a time where keeping the optional is useful.

### Previous usage:
```ts
type Type = {
    id?: number;
}

// Note the (!)
Builder<Type>().id!(1);
```

### Current usage
```ts
type Type = {
    id?: number;
}

Builder<Type>().id(1);
```