### PR TITLE
Return current value if no argument passed to the getter.

### DIFF
--- a/src/Builder.ts
+++ b/src/Builder.ts
@@ -1,5 +1,5 @@
 export type IBuilder<T> = {
-  [k in keyof T]-?: (arg: T[k]) => IBuilder<T>
+  [k in keyof T]-?: ((arg: T[k]) => IBuilder<T>) & (() => T[k]);
 }
 & {
   build(): T;
@@ -53,6 +53,11 @@ export function Builder<T>(typeOrTemplate?: Clazz<T> | Partial<T>,
         }
 
         return (x: unknown): unknown => {
+          // If no arguments passed return current value.
+          if (!arguments.length) {
+            return built[prop.toString()] || null;
+          }
+          
           built[prop.toString()] = x;
           return builder;
         };


### PR DESCRIPTION
Allow getting value from existing builder
```typescript
type T = {
  a: string | null;
  b?: number | null;
  c?: string | null;
  d?: string | null;
};

const builder = Builder<T>().a("text").b(123).c(null);

assert(builder.a() === "text");
assert(builder.b() === 123);
assert(isNull(builder.c()));
assert(isNull(builder.d()));
console.log(builder.build());
// { a: "text", b: 123, c: null }
```