### PR TITLE
exclude functions type from builder setter

### DIFF
--- a/src/Builder.ts
+++ b/src/Builder.ts
@@ -1,5 +1,5 @@
 export type IBuilder<T> = {
-  [k in keyof T]-?: ((arg: T[k]) => IBuilder<T>) & (() => T[k]);
+  [k in keyof T & string as T[k] extends ((...args: any[]) => any) ? never : `${k}`]-?: ((arg: T[k]) => IBuilder<T>) & (() => T[k]);
 }
 & {
   build(): T;

--- a/src/StrictBuilder.ts
+++ b/src/StrictBuilder.ts
@@ -1,5 +1,5 @@
 export type IStrictBuilder<T, B = Record<string, unknown>> = {
-  [k in keyof T]-?: ((arg: T[k]) => IStrictBuilder<T, B & Record<k, T[k]>>) & (() => T[k]);
+  [k in keyof T & string as T[k] extends ((...args: any[]) => any) ? never : `${k}`]-?: ((arg: T[k]) => IStrictBuilder<T, B & Record<k, T[k]>>) & (() => T[k]);
 }
 & {
   build: B extends T ? () => T : never


### PR DESCRIPTION
```
class Test {
  property!: number;
  method(v: number) {
    return null;
  }
}

//before
Builder(Test).property(1).method(() => null).build(); // ok

// after
Builder(Test).property(1).build(); // we don't have method in builder type
```